### PR TITLE
[FLINK-14319][api] Register user jar files in execution environment.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/Plan.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/Plan.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.cache.DistributedCache.DistributedCacheEntry;
 import org.apache.flink.api.common.operators.GenericDataSinkBase;
 import org.apache.flink.api.common.operators.Operator;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.util.Visitable;
 import org.apache.flink.util.Visitor;
 
@@ -62,6 +63,8 @@ public class Plan implements Visitable<Operator<?>> {
 
 	/** Hash map for files in the distributed cache: registered name to cache entry. */
 	protected HashMap<String, DistributedCacheEntry> cacheFile = new HashMap<>();
+
+	protected List<Path> userJars = new ArrayList<>();
 
 	/** Config object for runtime execution parameters. */
 	protected ExecutionConfig executionConfig;
@@ -350,12 +353,27 @@ public class Plan implements Visitable<Operator<?>> {
 	}
 
 	/**
-	 * Return the registered cached files.
-	 *
+	 * Registers a jar file in program level
+	 * @param jarFile The path of the jar file
+	 */
+	public void registerUserJarFile(Path jarFile) {
+		this.userJars.add(jarFile);
+	}
+
+	/**
+	 * return the registered caches files
 	 * @return Set of (name, filePath) pairs
 	 */
 	public Set<Entry<String, DistributedCacheEntry>> getCachedFiles() {
 		return this.cacheFile.entrySet();
+	}
+
+	/**
+	 * return the registered user jar files
+	 * @return
+	 */
+	public List<Path> getUserJars() {
+		return userJars;
 	}
 
 	public int getMaximumParallelism() {

--- a/flink-fs-tests/pom.xml
+++ b/flink-fs-tests/pom.xml
@@ -146,6 +146,27 @@ under the License.
 					</environmentVariables>
 				</configuration>
 			</plugin>
+
+			<plugin>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<version>2.4</version><!--$NO-MVN-MAN-VER$-->
+				<executions>
+					<execution>
+						<id>create-user-jar</id>
+						<phase>process-test-classes</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+						<configuration>
+							<finalName>userjar</finalName>
+							<attach>false</attach>
+							<descriptors>
+								<descriptor>src/test/assembly/test-userjar-assembly.xml</descriptor>
+							</descriptors>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/flink-fs-tests/src/test/assembly/test-userjar-assembly.xml
+++ b/flink-fs-tests/src/test/assembly/test-userjar-assembly.xml
@@ -1,0 +1,36 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+
+-->
+
+<assembly>
+	<id>test-jar</id>
+	<formats>
+		<format>jar</format>
+	</formats>
+	<includeBaseDirectory>false</includeBaseDirectory>
+	<fileSets>
+		<fileSet>
+			<directory>${project.build.testOutputDirectory}</directory>
+			<outputDirectory>/</outputDirectory>
+			<includes>
+				<include>org/apache/flink/hdfstests/userjar/MapFunc.class</include>
+			</includes>
+		</fileSet>
+	</fileSets>
+</assembly>

--- a/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/userjar/MapFunc.java
+++ b/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/userjar/MapFunc.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.hdfstests.userjar;
+
+/**
+ * Simulated function for testing.
+ */
+public class MapFunc {
+	/**
+	 * @param value
+	 * @return "Hello Flink!" always.
+	 */
+	public String eval(String value) {
+		return "Hello Flink!";
+	}
+}

--- a/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/userjar/UserJarDfsTest.java
+++ b/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/userjar/UserJarDfsTest.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.hdfstests.userjar;
+
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.util.NetUtils;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.net.URI;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for adding user jar file via HDFS.
+ */
+public class UserJarDfsTest extends TestLogger {
+
+	private static final String localJarFile = "target/userjar-test-jar.jar";
+	private static final String funcName = "org.apache.flink.test.userjar.MapFunc";
+
+	@ClassRule
+	public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+
+	@ClassRule
+	public static final MiniClusterWithClientResource MINI_CLUSTER_RESOURCE = new MiniClusterWithClientResource(
+		new MiniClusterResourceConfiguration.Builder()
+			.setNumberTaskManagers(1)
+			.setNumberSlotsPerTaskManager(1)
+			.build());
+
+	private static MiniDFSCluster hdfsCluster;
+	private static Configuration conf = new Configuration();
+
+	private static Path dfsJarFile;
+
+	@BeforeClass
+	public static void setup() throws Exception {
+		File dataDir = TEMP_FOLDER.newFolder();
+
+		conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, dataDir.getAbsolutePath());
+		MiniDFSCluster.Builder builder = new MiniDFSCluster.Builder(conf);
+		hdfsCluster = builder.build();
+
+		String hdfsURI = "hdfs://"
+			+ NetUtils.hostAndPortToUrlString(hdfsCluster.getURI().getHost(), hdfsCluster.getNameNodePort())
+			+ "/";
+
+		FileSystem dfs = FileSystem.get(new URI(hdfsURI));
+		dfsJarFile = writeFile(dfs, dfs.getHomeDirectory(), "userjar.jar");
+	}
+
+	private static Path writeFile(FileSystem dfs, Path rootDir, String fileName) throws IOException {
+		Path file = new Path(rootDir, fileName);
+		try (
+			DataOutputStream outStream = new DataOutputStream(dfs.create(file,
+				FileSystem.WriteMode.OVERWRITE))) {
+			InputStream in = new FileInputStream(new File(localJarFile));
+			byte[] b = new byte[4096];
+			int len;
+			while ((len = in.read(b)) != -1) {
+				outStream.write(b, 0, len);
+			}
+		}
+		return file;
+	}
+
+	@AfterClass
+	public static void teardown() {
+		hdfsCluster.shutdown();
+	}
+
+	@Test
+	public void testUserJarViaDFS() throws Exception {
+
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(1);
+
+		env.registerUserJarFile(dfsJarFile.toString());
+
+		env.fromElements("1")
+			.map(new UdfMapper())
+			.addSink(new DiscardingSink<>());
+
+		env.execute();
+	}
+
+	private static class UdfMapper extends RichMapFunction<String, String>{
+		private Object mapper;
+		private Method mapFunc;
+
+		@Override
+		public void open(org.apache.flink.configuration.Configuration parameters) throws Exception {
+			ClassLoader loader = getRuntimeContext().getUserCodeClassLoader();
+			Class clazz = Class.forName("org.apache.flink.hdfstests.userjar.MapFunc", false, loader);
+			mapper = clazz.newInstance();
+			mapFunc = clazz.getDeclaredMethod("eval", String.class);
+		}
+
+		@Override
+		public String map(String value) throws Exception {
+			String hello = (String) mapFunc.invoke(mapper, value);
+			assertEquals("Hello Flink!", hello);
+			return hello;
+		}
+	}
+}

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/plantranslate/JobGraphGenerator.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/plantranslate/JobGraphGenerator.java
@@ -268,7 +268,9 @@ public class JobGraphGenerator implements Visitor<PlanNode> {
 			.map(entry -> Tuple2.of(entry.getKey(), entry.getValue()))
 			.collect(Collectors.toList());
 		addUserArtifactEntries(userArtifacts, graph);
-		
+
+		addUserJars(program.getOriginalPlan().getUserJars(), graph);
+
 		// release all references again
 		this.vertices = null;
 		this.chainedTasks = null;
@@ -279,6 +281,14 @@ public class JobGraphGenerator implements Visitor<PlanNode> {
 
 		// return job graph
 		return graph;
+	}
+
+	public static void addUserJars(List<Path> userJars, JobGraph jobGraph) {
+		if(userJars != null) {
+			for (Path jar: userJars) {
+				jobGraph.addJar(jar);
+			}
+		}
 	}
 
 	public static void addUserArtifactEntries(Collection<Tuple2<String, DistributedCache.DistributedCacheEntry>> userArtifacts, JobGraph jobGraph) {

--- a/flink-python/pyflink/dataset/tests/test_execution_environment_completeness.py
+++ b/flink-python/pyflink/dataset/tests/test_execution_environment_completeness.py
@@ -49,7 +49,8 @@ class ExecutionEnvironmentCompletenessTests(PythonAPICompletenessTestCase,
                 'getIdString', 'setSessionTimeout', 'fromElements', 'createRemoteEnvironment',
                 'startNewSession', 'fromCollection', 'readTextFileWithValue', 'registerDataSink',
                 'createCollectionsEnvironment', 'readFile', 'readFileOfPrimitives',
-                'generateSequence', 'areExplicitEnvironmentsAllowed', 'createInput'}
+                'generateSequence', 'areExplicitEnvironmentsAllowed', 'createInput',
+                'registerUserJarFile', 'registerUserJarFileWithPlan'}
 
 
 if __name__ == '__main__':

--- a/flink-python/pyflink/datastream/tests/test_stream_execution_environment_completeness.py
+++ b/flink-python/pyflink/datastream/tests/test_stream_execution_environment_completeness.py
@@ -48,7 +48,7 @@ class StreamExecutionEnvironmentCompletenessTests(PythonAPICompletenessTestCase,
                 'readFileStream', 'isForceCheckpointing', 'readFile', 'clean',
                 'createInput', 'createLocalEnvironmentWithWebUI', 'fromCollection',
                 'socketTextStream', 'initializeContextEnvironment', 'readTextFile', 'addSource',
-                'setNumberOfExecutionRetries'}
+                'setNumberOfExecutionRetries', 'registerUserJarFile', 'getUserJars'}
 
 
 if __name__ == '__main__':

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
@@ -464,6 +464,18 @@ class ExecutionEnvironment(javaEnv: JavaEnv) {
   }
 
   /**
+   * Registers a jar file to load in this Flink job dynamically.
+   * This jar file would be shipped along with the job submission,
+   * and then, the jar file is loaded into user code class loader automatically.
+   *
+   * @param jarFile The path of the jar file (e.g., "file:///path/to/jar"
+   *                or "hdfs://host:port/path/to/jar").
+   */
+  def registerUserJarFile(jarFile: String): Unit = {
+    javaEnv.registerUserJarFile(jarFile)
+  }
+
+  /**
    * Triggers the program execution. The environment will execute all parts of the program that have
    * resulted in a "sink" operation. Sink operations are for example printing results
    * [[DataSet.print]], writing results (e.g. [[DataSet.writeAsText]], [[DataSet.write]], or other

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -144,6 +144,7 @@ public abstract class StreamExecutionEnvironment {
 
 	protected final List<Tuple2<String, DistributedCache.DistributedCacheEntry>> cacheFile = new ArrayList<>();
 
+	protected final List<Path> userJars = new ArrayList<>();
 
 	// --------------------------------------------------------------------------------------------
 	// Constructor and Properties
@@ -161,6 +162,14 @@ public abstract class StreamExecutionEnvironment {
 	*/
 	public List<Tuple2<String, DistributedCache.DistributedCacheEntry>> getCachedFiles() {
 		return cacheFile;
+	}
+
+	/**
+	 * Get the list of user jar files that were registered for distribution among the task managers.
+	 * @return
+	 */
+	public List<Path> getUserJars() {
+		return userJars;
 	}
 
 	/**
@@ -1545,6 +1554,7 @@ public abstract class StreamExecutionEnvironment {
 		return new StreamGraphGenerator(transformations, config, checkpointCfg)
 			.setStateBackend(defaultStateBackend)
 			.setChaining(isChainingEnabled)
+			.setUserJar(userJars)
 			.setUserArtifacts(cacheFile)
 			.setTimeCharacteristic(timeCharacteristic)
 			.setDefaultBufferTimeout(bufferTimeout);
@@ -1846,5 +1856,15 @@ public abstract class StreamExecutionEnvironment {
 	 */
 	public void registerCachedFile(String filePath, String name, boolean executable) {
 		this.cacheFile.add(new Tuple2<>(name, new DistributedCache.DistributedCacheEntry(filePath, executable)));
+	}
+
+	/**
+	 * Registers a jar file to load in this Flink job dynamically. This jar file would be shipped along with the job submission,
+	 *  and then, the jar file is loaded into user code class loader automatically.
+	 * @param jarFile The path of the jar file (e.g., "file:///path/to/jar" or "hdfs://host:port/path/to/jar").
+	 */
+	public void registerUserJarFile(String jarFile) {
+		Path path = new Path(jarFile);
+		this.userJars.add(path);
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -30,6 +30,7 @@ import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.typeutils.MissingTypeInfo;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.optimizer.plan.StreamingPlan;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.ScheduleMode;
@@ -109,6 +110,7 @@ public class StreamGraph extends StreamingPlan {
 	protected Map<Integer, Long> vertexIDtoLoopTimeout;
 	private StateBackend stateBackend;
 	private Set<Tuple2<StreamNode, StreamNode>> iterationSourceSinkPairs;
+	private List<Path> userJars;
 
 	public StreamGraph(ExecutionConfig executionConfig, CheckpointConfig checkpointConfig) {
 		this.executionConfig = checkNotNull(executionConfig);
@@ -730,5 +732,13 @@ public class StreamGraph extends StreamingPlan {
 		catch (Exception e) {
 			throw new RuntimeException("JSON plan creation failed", e);
 		}
+	}
+
+	public List<Path> getUserJars() {
+		return userJars;
+	}
+
+	public void setUserJars(List<Path> userJars) {
+		this.userJars = userJars;
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.cache.DistributedCache;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.jobgraph.ScheduleMode;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 import org.apache.flink.runtime.state.StateBackend;
@@ -131,6 +132,9 @@ public class StreamGraphGenerator {
 
 	// This is used to assign a unique ID to iteration source/sink
 	protected static Integer iterationIdCounter = 0;
+
+	private List<Path> userJars;
+
 	public static int getNewIterationNodeId() {
 		iterationIdCounter--;
 		return iterationIdCounter;
@@ -193,11 +197,17 @@ public class StreamGraphGenerator {
 		return this;
 	}
 
+	public StreamGraphGenerator setUserJar(List<Path> userJars) {
+		this.userJars = userJars;
+		return this;
+	}
+
 	public StreamGraph generate() {
 		streamGraph = new StreamGraph(executionConfig, checkpointConfig);
 		streamGraph.setStateBackend(stateBackend);
 		streamGraph.setChaining(chaining);
 		streamGraph.setScheduleMode(scheduleMode);
+		streamGraph.setUserJars(userJars);
 		streamGraph.setUserArtifacts(userArtifacts);
 		streamGraph.setTimeCharacteristic(timeCharacteristic);
 		streamGraph.setJobName(jobName);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -166,6 +166,8 @@ public class StreamingJobGraphGenerator {
 
 		configureCheckpointing();
 
+		JobGraphGenerator.addUserJars(streamGraph.getUserJars(), jobGraph);
+
 		JobGraphGenerator.addUserArtifactEntries(streamGraph.getUserArtifacts(), jobGraph);
 
 		// set the ExecutionConfig last when it has been finalized

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -27,16 +27,15 @@ import org.apache.flink.api.java.typeutils.ResultTypeQueryable
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer
 import org.apache.flink.api.scala.ClosureCleaner
 import org.apache.flink.configuration.Configuration
-import org.apache.flink.runtime.state.AbstractStateBackend
-import org.apache.flink.runtime.state.StateBackend
+import org.apache.flink.runtime.state.{AbstractStateBackend, StateBackend}
 import org.apache.flink.streaming.api.environment.{StreamExecutionEnvironment => JavaEnv}
-import org.apache.flink.streaming.api.functions.source._
 import org.apache.flink.streaming.api.functions.source.SourceFunction.SourceContext
+import org.apache.flink.streaming.api.functions.source._
 import org.apache.flink.streaming.api.{CheckpointingMode, TimeCharacteristic}
 import org.apache.flink.util.SplittableIterator
 
-import scala.collection.JavaConverters._
 import _root_.scala.language.implicitConversions
+import scala.collection.JavaConverters._
 
 @Public
 class StreamExecutionEnvironment(javaEnv: JavaEnv) {
@@ -55,6 +54,11 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
     * Gets cache files.
     */
   def getCachedFiles = javaEnv.getCachedFiles
+
+  /**
+    * Gets user jar files.
+    */
+  def getUserJars = javaEnv.getUserJars
 
   /**
    * Sets the parallelism for operations executed through this environment.
@@ -727,6 +731,18 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
     */
   def registerCachedFile(filePath: String, name: String, executable: Boolean): Unit = {
     javaEnv.registerCachedFile(filePath, name, executable)
+  }
+
+  /**
+    * Registers a jar file to load in this Flink job dynamically.
+    * This jar file would be shipped along with the job submission,
+    * and then, the jar file is loaded into user code class loader automatically.
+    *
+    * @param jarFile The path of the jar file (e.g., "file:///path/to/jar"
+    *                or "hdfs://host:port/path/to/jar").
+    */
+  def registerUserJarFile(jarFile: String): Unit = {
+    javaEnv.registerUserJarFile(jarFile)
   }
 }
 

--- a/flink-tests/pom.xml
+++ b/flink-tests/pom.xml
@@ -594,6 +594,21 @@ under the License.
 							</descriptors>
 						</configuration>
 					</execution>
+
+					<execution>
+						<id>create-user-jar</id>
+						<phase>process-test-classes</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+						<configuration>
+							<finalName>userjar</finalName>
+							<attach>false</attach>
+							<descriptors>
+								<descriptor>src/test/assembly/test-userjar-assembly.xml</descriptor>
+							</descriptors>
+						</configuration>
+					</execution>
 				</executions>
 			</plugin>
 

--- a/flink-tests/src/test/assembly/test-userjar-assembly.xml
+++ b/flink-tests/src/test/assembly/test-userjar-assembly.xml
@@ -1,0 +1,36 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+
+-->
+
+<assembly>
+	<id>test-jar</id>
+	<formats>
+		<format>jar</format>
+	</formats>
+	<includeBaseDirectory>false</includeBaseDirectory>
+	<fileSets>
+		<fileSet>
+			<directory>${project.build.testOutputDirectory}</directory>
+			<outputDirectory>/</outputDirectory>
+			<includes>
+				<include>org/apache/flink/test/userjar/MapFunc.class</include>
+			</includes>
+		</fileSet>
+	</fileSets>
+</assembly>

--- a/flink-tests/src/test/java/org/apache/flink/test/userjar/AddingUserJarTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/userjar/AddingUserJarTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.userjar;
+
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.test.util.AbstractTestBase;
+
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test adding user jar file.
+ */
+public class AddingUserJarTest extends AbstractTestBase {
+	private String testJar = "target/userjar-test-jar.jar";
+
+	@Test
+	public void testBatchUserJar() throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		env.registerUserJarFile(testJar);
+		env.fromElements("1").map(new UdfMapper()).count();
+	}
+
+	@Test
+	public void testStreamingUserJar() throws Exception {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.registerUserJarFile(testJar);
+		env.fromElements("1").map(new UdfMapper()).addSink(new DiscardingSink<>());
+		env.execute();
+	}
+
+	private static class UdfMapper extends RichMapFunction<String, String>{
+		private Object mapper;
+		private Method mapFunc;
+
+		@Override
+		public void open(Configuration parameters) throws Exception {
+			ClassLoader loader = getRuntimeContext().getUserCodeClassLoader();
+			Class clazz = Class.forName("org.apache.flink.test.userjar.MapFunc", false, loader);
+			mapper = clazz.newInstance();
+			mapFunc = clazz.getDeclaredMethod("eval", String.class);
+		}
+
+		@Override
+		public String map(String value) throws Exception {
+			String hello = (String) mapFunc.invoke(mapper, value);
+			assertEquals("Hello Flink!", hello);
+			return hello;
+		}
+	}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/userjar/MapFunc.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/userjar/MapFunc.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.userjar;
+
+/**
+ * Simulated function for testing.
+ */
+public class MapFunc {
+	/**
+	 * @param value
+	 * @return "Hello Flink!" always.
+	 */
+	public String eval(String value) {
+		return "Hello Flink!";
+	}
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
